### PR TITLE
Add qualtrics survey data fetch and export

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -36,3 +36,4 @@ jobs:
         run: |
           cf add-network-policy gdrive outbound-proxy -s ${{ steps.cf-setup.outputs.target-environment }}-public --protocol tcp --port 8080
           cf add-network-policy gdrive es-proxy -s ${{ steps.cf-setup.outputs.target-environment }} --protocol tcp --port 8080
+          cf add-network-policy gdrive qualtrix -s ${{ steps.cf-setup.outputs.target-environment }} --protocol tcp --port 8080

--- a/gdrive/error.py
+++ b/gdrive/error.py
@@ -1,0 +1,6 @@
+"""
+Custom Export Error. For specific raise/catch use.
+"""
+class ExportError(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/gdrive/error.py
+++ b/gdrive/error.py
@@ -1,6 +1,8 @@
 """
 Custom Export Error. For specific raise/catch use.
 """
+
+
 class ExportError(Exception):
     def __init__(self, message):
         super().__init__(message)

--- a/gdrive/export_api.py
+++ b/gdrive/export_api.py
@@ -55,5 +55,4 @@ async def survey_upload_response(request: SurveyResponseModel):
 
         return response
     except error.ExportError as e:
-        print("about to raise exception")
         raise HTTPException(status_code=400, detail=e.args)

--- a/gdrive/export_api.py
+++ b/gdrive/export_api.py
@@ -28,9 +28,11 @@ async def upload_file(interactionId):
     parent = client.create_folder(interactionId, settings.ROOT_DIRECTORY)
     client.upload_basic("analytics.json", parent, export_bytes)
 
+
 class SurveyResponseModel(BaseModel):
     surveyId: str
     responseId: str
+
 
 @router.post("/survey-export")
 async def survey_upload_response(request: SurveyResponseModel):
@@ -40,8 +42,10 @@ async def survey_upload_response(request: SurveyResponseModel):
 
     try:
         # call function that invokes qualtrics microservice to get response
-        response = export_client.get_qualtrics_response(request.surveyId, request.responseId)
-        
+        response = export_client.get_qualtrics_response(
+            request.surveyId, request.responseId
+        )
+
         # call function that queries ES for all analytics entries (flow interactionId) with responseId
         interactionIds = export_client.export_response(request.responseId, response)
 
@@ -52,7 +56,4 @@ async def survey_upload_response(request: SurveyResponseModel):
         return response
     except error.ExportError as e:
         print("about to raise exception")
-        raise HTTPException(
-            status_code=400,
-            detail=e.args
-        )
+        raise HTTPException(status_code=400, detail=e.args)

--- a/gdrive/export_client.py
+++ b/gdrive/export_client.py
@@ -159,6 +159,7 @@ def get_qualtrics_response(surveyId: str, responseId: str):
     r = requests.post(
         settings.QUALTRICS_API_URL + "/response",
         json={"surveyId": surveyId, "responseId": responseId},
+        timeout=30,  # qualtrics microservice retries as it waits for response to become available
     )
     if r.status_code != 200:
         raise error.ExportError(

--- a/gdrive/export_client.py
+++ b/gdrive/export_client.py
@@ -157,7 +157,7 @@ def codename(data: str):
 
 def get_qualtrics_response(surveyId: str, responseId: str):
     r = requests.post(
-        settings.QUALTRICS_API_URL + "/response",
+        settings.QUALTRICS_API_URL + ":" + settings.QUALTRICS_API_PORT + "/response",
         json={"surveyId": surveyId, "responseId": responseId},
         timeout=30,  # qualtrics microservice retries as it waits for response to become available
     )

--- a/gdrive/settings.py
+++ b/gdrive/settings.py
@@ -24,6 +24,7 @@ ES_HOST = os.getenv("ES_HOST")
 ES_PORT = os.getenv("ES_PORT")
 
 QUALTRICS_API_URL = os.getenv("QUALTRICS_API_URL")
+QUALTRICS_API_PORT = os.getenv("QUALTRICS_API_PORT")
 
 try:
     vcap_services = os.getenv("VCAP_SERVICES")

--- a/gdrive/settings.py
+++ b/gdrive/settings.py
@@ -23,6 +23,8 @@ CREDENTIALS = None
 ES_HOST = os.getenv("ES_HOST")
 ES_PORT = os.getenv("ES_PORT")
 
+QUALTRICS_API_URL = os.getenv("QUALTRICS_API_URL")
+
 try:
     vcap_services = os.getenv("VCAP_SERVICES")
     config = {}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,4 +14,6 @@ applications:
     env:
       ES_HOST: identity-idva-es-proxy-((ENVIRONMENT)).apps.internal
       ES_PORT: 8080
+      QUALTRICS_API_URL: identity-idva-qualtrix-((ENVIRONMENT)).apps.internal
+      QUALTRICS_API_PORT: 8080
       NO_PROXY: .apps.internal

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,3 +14,4 @@ applications:
     env:
       ES_HOST: identity-idva-es-proxy-((ENVIRONMENT)).apps.internal
       ES_PORT: 8080
+      NO_PROXY: .apps.internal


### PR DESCRIPTION
Two functions added and invoked by the new `/survey-export` endpoint:
- `get_qualtrics_response` - gets survey response if it exists
- `export_response` - gets analytics entries that contain a similar `responseId`, adds qualtrics response to existing document

`/survey-export` endpoint then uploads files to gdrive using existing gdrive function, `upload_file`