### PR TITLE
Run survey export as a background task

### DIFF
--- a/gdrive/export_api.py
+++ b/gdrive/export_api.py
@@ -7,10 +7,8 @@ import json
 import logging
 
 import fastapi
-from pydantic import BaseModel, typing
-from fastapi import Response, status, HTTPException
-from googleapiclient.http import HttpError
-from starlette.requests import Request
+from pydantic import BaseModel
+from fastapi import BackgroundTasks, responses
 
 from gdrive import export_client, client, settings, error
 
@@ -35,24 +33,34 @@ class SurveyResponseModel(BaseModel):
 
 
 @router.post("/survey-export")
-async def survey_upload_response(request: SurveyResponseModel):
+async def survey_upload_response(
+    request: SurveyResponseModel, background_tasks: BackgroundTasks
+):
     """
-    Single endpoint to handle qualtrics response fetching and exporting
+    Single endpoint that kicks off qualtrics response fetching and exporting
     """
 
+    background_tasks.add_task(
+        survey_upload_response_task, request.responseId, request.surveyId
+    )
+
+    return responses.JSONResponse(
+        status_code=202, content=f"Response {request.responseId} is being processed."
+    )
+
+
+async def survey_upload_response_task(responseId, surveyId):
+    """
+    Background task that handles qualtrics response fetching and exporting
+    """
     try:
-        # call function that invokes qualtrics microservice to get response
-        response = export_client.get_qualtrics_response(
-            request.surveyId, request.responseId
-        )
+        response = export_client.get_qualtrics_response(surveyId, responseId)
 
         # call function that queries ES for all analytics entries (flow interactionId) with responseId
-        interactionIds = export_client.export_response(request.responseId, response)
+        interactionIds = export_client.export_response(responseId, response)
 
         # export list of interactionIds to gdrive
         for id in interactionIds:
             await upload_file(id)
-
-        return response
     except error.ExportError as e:
-        raise HTTPException(status_code=400, detail=e.args)
+        log.error(e.args)

--- a/gdrive/export_client.py
+++ b/gdrive/export_client.py
@@ -80,6 +80,15 @@ def export(interactionId):
     return output
 
 
+def codename(data: str):
+    codenames = settings.CODE_NAMES
+
+    for service, codename in codenames.items():
+        data = re.sub(service, codename, data, flags=re.IGNORECASE)
+
+    return data
+
+
 def export_response(responseId, survey_response):
     es = OpenSearch(
         hosts=[{"host": settings.ES_HOST, "port": settings.ES_PORT}], timeout=300
@@ -144,15 +153,6 @@ def export_response(responseId, survey_response):
     results_update = es.update_by_query(index="_all", body=query_response_data)
 
     return list(map(lambda id: id["match"]["interactionId"], interactionIds_match))
-
-
-def codename(data: str):
-    codenames = settings.CODE_NAMES
-
-    for service, codename in codenames.items():
-        data = re.sub(service, codename, data, flags=re.IGNORECASE)
-
-    return data
 
 
 def get_qualtrics_response(surveyId: str, responseId: str):


### PR DESCRIPTION
Survey export endpoint now returns 200 right away, processing the response aggregation and export as a background task.